### PR TITLE
Add a missing parameter to the Laplacian Smooth filter (cotangentWeight)

### DIFF
--- a/apps/mesh_object
+++ b/apps/mesh_object
@@ -60,6 +60,7 @@ FILTER_SCRIPT_PIVOTING='''
  <filter name="Laplacian Smooth">
   <Param type="RichInt" value="3" name="stepSmoothNum"/>
   <Param type="RichBool" value="true" name="Boundary"/>
+  <Param type="RichBool" value="false" name="cotangentWeight"/>
   <Param type="RichBool" value="false" name="Selected"/>
  </filter>
 </FilterScript>


### PR DESCRIPTION
According to current code on [meshlab](http://sourceforge.net/p/meshlab/code/HEAD/tree/trunk/meshlab/src/meshlabplugins/filter_unsharp/filter_unsharp.cpp#l318)