### PR TITLE
New param to decide to close the bottom of the object

### DIFF
--- a/apps/mesh_object
+++ b/apps/mesh_object
@@ -66,26 +66,115 @@ FILTER_SCRIPT_PIVOTING='''
   <Param type="RichFloat" value="90" name="CreaseThr"/>
   <Param type="RichBool" value="false" name="DeleteFaces"/>
  </filter>
+ <filter name="Close Holes">
+  <Param type="RichInt" value="30" name="MaxHoleSize"/>
+  <Param type="RichBool" value="false" name="Selected"/>
+  <Param type="RichBool" value="true" name="NewFaceSelected"/>
+  <Param type="RichBool" value="true" name="SelfIntersection"/>
+ </filter>
  <filter name="Laplacian Smooth">
   <Param type="RichInt" value="1" name="stepSmoothNum"/>
   <Param type="RichBool" value="true" name="Boundary"/>
   <Param type="RichBool" value="true" name="cotangentWeight"/>
   <Param type="RichBool" value="false" name="Selected"/>
  </filter>
+  <filter name="Merge Close Vertices">
+  <Param type="RichAbsPerc" value="2.4916e-05" min="0" name="Threshold" max="0.00249156"/>
+ </filter>
+ <filter name="Remove Isolated pieces (wrt Face Num.)">
+  <Param type="RichInt" value="100" name="MinComponentSize"/>
+ </filter>
 </FilterScript>
 '''
+
+CONVEX_HULL_BASE='''
+<!DOCTYPE FilterScript>
+<FilterScript>
+ <filter name="Convex Hull">
+  <Param type="RichBool" value="false" name="reorient"/>
+ </filter>
+ <filter name="Conditional Vertex Selection">
+  <Param type="RichString" value="(z &lt; 0.02)" name="condSelect"/>
+  <Param type="RichBool" value="true" name="strictSelect"/>
+ </filter>
+ <filter name="Invert Selection">
+  <Param type="RichBool" value="true" name="InvFaces"/>
+  <Param type="RichBool" value="true" name="InvVerts"/>
+ </filter>
+ <filter name="Delete Selected Faces and Vertices"/>
+</FilterScript>
+'''
+
+MERGE_SCRIPT='''
+<!DOCTYPE FilterScript>
+<FilterScript>
+ <filter name="Flatten Visible Layers">
+  <Param type="RichBool" value="false" name="MergeVisible"/>
+  <Param type="RichBool" value="true" name="DeleteLayer"/>
+  <Param type="RichBool" value="false" name="MergeVertices"/>
+  <Param type="RichBool" value="true" name="AlsoUnreferenced"/>
+ </filter>
+</FilterScript>
+'''
+
+SUBSAMPLING_SCRIPT='''
+<!DOCTYPE FilterScript>
+<FilterScript>
+ <filter name="Poisson-disk Sampling">
+  <Param type="RichInt" value="1000" name="SampleNum"/>
+  <Param type="RichAbsPerc" value="0.001" min="0" name="Radius" max="0.129553"/>
+  <Param type="RichInt" value="20" name="MontecarloRate"/>
+  <Param type="RichBool" value="false" name="ApproximateGeodesicDistance"/>
+  <Param type="RichBool" value="false" name="Subsample"/>
+  <Param type="RichBool" value="false" name="RefineFlag"/>
+  <Param type="RichMesh" value="0" name="RefineMesh"/>
+ </filter>
+</FilterScript>
+'''
+
 #meshlabserver -i cloud_44ed68c2b66cc8aefc7df45fd63c4ac8_00000.ply -o mug.stl -s meshlab.xml.mlx
 
-def meshlab(filename_in, filename_out):
+def meshlab(filename_in, filename_out, args):
     import subprocess
+    env = os.environ
+    env['LC_NUMERIC'] = 'C'
     f = NamedTemporaryFile(delete=False)
     script = f.name
     f.write(FILTER_SCRIPT_PIVOTING)
     f.close()
-    env = os.environ
-    env['LC_NUMERIC'] = 'C'
     subprocess.Popen('meshlabserver -i ' + filename_in + ' -o ' + filename_out + ' -s ' + script,
                      env=env, cwd=os.getcwd(), shell=True).wait()
+
+    if args.close:
+        dir_path = tempfile.mkdtemp()
+        hullfile = os.path.join(dir_path, 'cloud_%s_%05d_hull.stl' % (str(session.id), 0))
+        mergedfile = os.path.join(dir_path, 'cloud_%s_%05d_merged.stl' % (str(session.id), 0))
+        subsampledfile = os.path.join(dir_path, 'cloud_%s_%05d_subsampled.ply' % (str(session.id), 0))
+        f = NamedTemporaryFile(delete=False)
+        script = f.name
+        f.write(CONVEX_HULL_BASE)
+        f.close()
+        subprocess.Popen('meshlabserver -i ' + filename_out + ' -o ' + hullfile + ' -s ' + script,
+                        env=env, cwd=os.getcwd(), shell=True).wait()
+        f = NamedTemporaryFile(delete=False)
+        script = f.name
+        f.write(MERGE_SCRIPT)
+        f.close()
+        subprocess.Popen('meshlabserver -i ' + filename_out + ' ' + hullfile + ' -o ' + mergedfile + ' -s ' + script,
+                        env=env, cwd=os.getcwd(), shell=True).wait()
+        f = NamedTemporaryFile(delete=False)
+        script = f.name
+        f.write(SUBSAMPLING_SCRIPT)
+        f.close()
+        subprocess.Popen('meshlabserver -i ' + mergedfile + ' -o ' + subsampledfile + ' -s ' + script,
+                        env=env, cwd=os.getcwd(), shell=True).wait()
+        f = NamedTemporaryFile(delete=False)
+        script = f.name
+        f.write(FILTER_SCRIPT_PIVOTING)
+        f.close()
+        subprocess.Popen('meshlabserver -i ' + subsampledfile + ' -o ' + filename_out + ' -s ' + script,
+                        env=env, cwd=os.getcwd(), shell=True).wait()
+      
     os.unlink(script)
 
 def simple_mesh_session(dbs, session, args):
@@ -158,7 +247,7 @@ def simple_mesh_session(dbs, session, args):
     ply_name = os.path.join(dir_path, 'cloud_%s_%05d.ply' % (str(session.id), 0))
     ply_name = 'cloud_%s_%05d.ply' % (str(session.id), 0)
     mesh_name = os.path.join(dir_path, 'cloud_%s.stl' % str(session.id))
-    meshlab(ply_name, mesh_name)
+    meshlab(ply_name, mesh_name, args)
     if args.commit:
         upload_mesh(dbs, session, ply_name, mesh_name)
         shutil.rmtree(dir_path)
@@ -172,6 +261,9 @@ def parse_args():
                         const=True, default=False,
                         help='Compute meshes for all possible sessions.')
     parser.add_argument('--visualize', dest='visualize', action='store_const',
+                        const=True, default=False,
+                        help='Turn on visualization')
+    parser.add_argument('--close', dest='close', action='store_const',
                         const=True, default=False,
                         help='Turn on visualization')
     dbtools.add_db_arguments(parser)


### PR DESCRIPTION
As the object during capture is place on the board you are never able to see the bottom of the object. During reconstruction this leads to creating a hole in the object that does not actually exist.

Like proposed there https://github.com/wg-perception/capture/issues/18 , I guess the proper way would be to flip the object and do a second capture, then use some alignment algorithm in PCL to get a fusion of the two capture and hence get a full object for reconstruction.

For now, I am worked a little on the Meshlab scripts and found a way to add a flat bottom to the object by using its convex hull. You just have to use the `--close` flag to add a bottom to the object.

See the difference here:
![mesh_opened](https://cloud.githubusercontent.com/assets/5452370/14177671/b259e640-f757-11e5-900a-1fab9e6263c5.png)

![mesh_closed](https://cloud.githubusercontent.com/assets/5452370/14177678/b646d574-f757-11e5-81a9-97a38756a97f.png)


I have tested it on several objects, and it seems to work fine. 
This is a fine temporary hack before we code a nice way of aligning twoo set of captures.
For example, my hack won't fix this, because there is no points below the camera lens
![mesh_cam](https://cloud.githubusercontent.com/assets/5452370/14177833/5fcb8d56-f758-11e5-8799-96dc94911af2.png)
